### PR TITLE
Support for inheritance

### DIFF
--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -53,6 +53,7 @@
     <Compile Include="PropertiesOfSameType.cs" />
     <Compile Include="PrimitiveValues.cs" />
     <Compile Include="InAssemblyUsage.cs" />
+    <Compile Include="ReferenceInheritance.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ReferenceAssembly\ReferenceAssembly.csproj">

--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -39,6 +39,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Inheritance.cs" />
     <Compile Include="MultipleConstructors2.cs" />
     <Compile Include="MultipleConstructorsOnlyOneIsPublic.cs" />
     <Compile Include="NoWithStub.cs" />

--- a/AssemblyToProcess/Inheritance.cs
+++ b/AssemblyToProcess/Inheritance.cs
@@ -8,9 +8,9 @@
             this.Value2 = value2;
         }
 
-        public int Value1 { get; set; }
+        public int Value1 { get; }
 
-        public string Value2 { get; set; }
+        public string Value2 { get; }
 
         public BaseInheritance With<T>(T value) => this;
     }
@@ -23,7 +23,7 @@
             this.Value3 = value3;
         }
 
-        public long Value3 { get; set; }
+        public long Value3 { get; }
 
         public new Inheritance With<T>(T value) => this;
     }

--- a/AssemblyToProcess/Inheritance.cs
+++ b/AssemblyToProcess/Inheritance.cs
@@ -1,0 +1,30 @@
+﻿namespace AssemblyToProcess
+{
+    public class BaseInheritance
+    {
+        public BaseInheritance(int value1, string value2)
+        {
+            this.Value1 = value1;
+            this.Value2 = value2;
+        }
+
+        public int Value1 { get; set; }
+
+        public string Value2 { get; set; }
+
+        public BaseInheritance With<T>(T value) => this;
+    }
+
+    public class Inheritance : BaseInheritance
+    {
+        public Inheritance(int value1, string value2, long value3)
+            : base(value1, value2)
+        {
+            this.Value3 = value3;
+        }
+
+        public long Value3 { get; set; }
+
+        public new Inheritance With<T>(T value) => this;
+    }
+}

--- a/AssemblyToProcess/ReferenceInheritance.cs
+++ b/AssemblyToProcess/ReferenceInheritance.cs
@@ -8,7 +8,7 @@
             this.Value3 = value3;
         }
 
-        public long Value3 { get; set; }
+        public long Value3 { get; }
 
         public ReferenceInheritance With<T>(T value) => this;
     }

--- a/AssemblyToProcess/ReferenceInheritance.cs
+++ b/AssemblyToProcess/ReferenceInheritance.cs
@@ -1,0 +1,15 @@
+﻿namespace AssemblyToProcess
+{
+    public class ReferenceInheritance : ReferenceAssembly.BaseInheritance
+    {
+        public ReferenceInheritance(int value1, string value2, long value3)
+            : base(value1, value2)
+        {
+            this.Value3 = value3;
+        }
+
+        public long Value3 { get; set; }
+
+        public ReferenceInheritance With<T>(T value) => this;
+    }
+}

--- a/ReferenceAssembly/BaseInheritance.cs
+++ b/ReferenceAssembly/BaseInheritance.cs
@@ -1,0 +1,15 @@
+﻿namespace ReferenceAssembly
+{
+    public class BaseInheritance
+    {
+        public BaseInheritance(int value1, string value2)
+        {
+            this.Value1 = value1;
+            this.Value2 = value2;
+        }
+
+        public int Value1 { get; set; }
+
+        public string Value2 { get; set; }
+    }
+}

--- a/ReferenceAssembly/BaseInheritance.cs
+++ b/ReferenceAssembly/BaseInheritance.cs
@@ -8,8 +8,8 @@
             this.Value2 = value2;
         }
 
-        public int Value1 { get; set; }
+        public int Value1 { get; }
 
-        public string Value2 { get; set; }
+        public string Value2 { get; }
     }
 }

--- a/ReferenceAssembly/Properties/AssemblyInfo.cs
+++ b/ReferenceAssembly/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ReferenceAssembly")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ReferenceAssembly")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("1339aa3a-8712-4f25-b000-9e589d5b1284")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ReferenceAssembly/ReferenceAssembly.csproj
+++ b/ReferenceAssembly/ReferenceAssembly.csproj
@@ -1,16 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{E97E649F-B703-47E3-B18A-0871D3498742}</ProjectGuid>
+    <ProjectGuid>{1339AA3A-8712-4F25-B000-9E589D5B1284}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>AssemblyToProcess</RootNamespace>
-    <AssemblyName>AssemblyToProcess</AssemblyName>
+    <RootNamespace>ReferenceAssembly</RootNamespace>
+    <AssemblyName>ReferenceAssembly</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -36,28 +37,19 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Inheritance.cs" />
-    <Compile Include="MultipleConstructors2.cs" />
-    <Compile Include="MultipleConstructorsOnlyOneIsPublic.cs" />
-    <Compile Include="NoWithStub.cs" />
-    <Compile Include="NoMatchingProperty.cs" />
-    <Compile Include="MultipleConstructors.cs" />
-    <Compile Include="ConstructorWithSingleArgument.cs" />
-    <Compile Include="NoConstructor.cs" />
-    <Compile Include="ExplicitlyAskedForFullName.cs" />
-    <Compile Include="PropertyCasing.cs" />
-    <Compile Include="PropertiesOfSameType.cs" />
-    <Compile Include="PrimitiveValues.cs" />
-    <Compile Include="InAssemblyUsage.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\ReferenceAssembly\ReferenceAssembly.csproj">
-      <Project>{1339aa3a-8712-4f25-b000-9e589d5b1284}</Project>
-      <Name>ReferenceAssembly</Name>
-    </ProjectReference>
+    <Compile Include="BaseInheritance.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
 </Project>

--- a/Tests/WeaverTests.cs
+++ b/Tests/WeaverTests.cs
@@ -71,6 +71,28 @@ public class WeaverTests
     }
 
     [Test]
+    public void Inheritance_WithIsInjected()
+    {
+        var type = assembly.GetType("AssemblyToProcess.Inheritance");
+        var instance = (dynamic)Activator.CreateInstance(type, new object[] { 1, "Hello", 234234L });
+
+        var result1 = instance.With(123);
+        Assert.AreEqual(123, result1.Value1);
+        Assert.AreEqual(instance.Value2, result1.Value2);
+        Assert.AreEqual(instance.Value3, result1.Value3);
+
+        var result2 = instance.With("World");
+        Assert.AreEqual(instance.Value1, result2.Value1);
+        Assert.AreEqual("World", result2.Value2);
+        Assert.AreEqual(instance.Value3, result1.Value3);
+
+        var result3 = instance.With(31231L);
+        Assert.AreEqual(instance.Value1, result3.Value1);
+        Assert.AreEqual(instance.Value2, result3.Value2);
+        Assert.AreEqual(31231L, result3.Value3);
+    }
+
+    [Test]
     public void MultipleConstructorsOnlyOneIsPublic_WithIsInjected()
     {
         var type = assembly.GetType("AssemblyToProcess.MultipleConstructorsOnlyOneIsPublic");

--- a/With.Fody.sln
+++ b/With.Fody.sln
@@ -12,6 +12,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nuget", "NuGet\Nuget.csproj
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyToProcess", "AssemblyToProcess\AssemblyToProcess.csproj", "{E97E649F-B703-47E3-B18A-0871D3498742}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReferenceAssembly", "ReferenceAssembly\ReferenceAssembly.csproj", "{1339AA3A-8712-4F25-B000-9E589D5B1284}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +46,14 @@ Global
 		{E97E649F-B703-47E3-B18A-0871D3498742}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E97E649F-B703-47E3-B18A-0871D3498742}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E97E649F-B703-47E3-B18A-0871D3498742}.Release|x86.ActiveCfg = Release|Any CPU
+		{1339AA3A-8712-4F25-B000-9E589D5B1284}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1339AA3A-8712-4F25-B000-9E589D5B1284}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1339AA3A-8712-4F25-B000-9E589D5B1284}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1339AA3A-8712-4F25-B000-9E589D5B1284}.Debug|x86.Build.0 = Debug|Any CPU
+		{1339AA3A-8712-4F25-B000-9E589D5B1284}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1339AA3A-8712-4F25-B000-9E589D5B1284}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1339AA3A-8712-4F25-B000-9E589D5B1284}.Release|x86.ActiveCfg = Release|Any CPU
+		{1339AA3A-8712-4F25-B000-9E589D5B1284}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/With.Fody/ModuleWeaver.cs
+++ b/With.Fody/ModuleWeaver.cs
@@ -165,9 +165,8 @@ public class ModuleWeaver
     {
         // get the getter for the property anywhere in the hierachy with the given name
         return GetAllProperties(type)
-            .Where(pro => String.Compare(pro.Name, name, StringComparison.InvariantCultureIgnoreCase) == 0)
-            .Select(pro => pro.GetMethod)
-            .First();
+            .First(pro => String.Compare(pro.Name, name, StringComparison.InvariantCultureIgnoreCase) == 0)
+            .GetMethod;
     }
 
 }

--- a/With.Fody/ModuleWeaver.cs
+++ b/With.Fody/ModuleWeaver.cs
@@ -50,7 +50,7 @@ public class ModuleWeaver
     private static MethodDefinition GetValidConstructor(TypeDefinition type)
     {
         return type.GetConstructors()
-            .Where(ctor => ctor.Parameters.Count >= 2 && ctor.Parameters.All(par => type.Properties.Any(pro => IsPair(pro, par))))
+            .Where(ctor => ctor.Parameters.Count >= 2 && ctor.Parameters.All(par => GetAllProperties(type).Any(pro => IsPair(pro, par))))
             .Aggregate((MethodDefinition)null, (max, next) => next.Parameters.Count > (max?.Parameters.Count ?? -1) ? next : max);
     }
 

--- a/With.Fody/ModuleWeaver.cs
+++ b/With.Fody/ModuleWeaver.cs
@@ -46,8 +46,8 @@ public class ModuleWeaver
         return type.GetConstructors()
             .Where(ctor =>
                 ctor.Parameters.Count >= 2 &&
-                ctor.Parameters.All(par => type.Properties.Any(pro => IsPair(pro, par))) &&
-                type.Properties.All(pro => ctor.Parameters.Any(par => IsPair(pro, par)))
+                ctor.Parameters.All(par => GetAllProperties(type).Any(pro => IsPair(pro, par))) &&
+                GetAllProperties(type).All(pro => ctor.Parameters.Any(par => IsPair(pro, par)))
             )
             .FirstOrDefault();
     }
@@ -65,9 +65,9 @@ public class ModuleWeaver
         foreach (var property in ctor.Parameters)
         {
             var parameterName = property.Name;
-            var getter = type.Methods.First(m => m.IsGetter && string.Compare(m.Name, $"get_{property.Name}", StringComparison.InvariantCultureIgnoreCase) == 0);
+            var getter = GetPropertyGetter(type, parameterName);
 
-            string propertyName = ToPropertyName(property.Name);
+            var propertyName = ToPropertyName(property.Name);
             MethodDefinition method;
             var explicitName = $"With{propertyName}";
             if (type.Methods.Any(m => m.Name == explicitName)
@@ -97,7 +97,7 @@ public class ModuleWeaver
                 }
                 else
                 {
-                    var getterParameter = type.Methods.First(m => m.IsGetter && string.Compare(m.Name, $"get_{parameter.Name}", StringComparison.InvariantCultureIgnoreCase) == 0);
+                    var getterParameter = GetPropertyGetter(type, parameter.Name);
                     processor.Emit(OpCodes.Ldarg_0);
                     processor.Emit(OpCodes.Call, getterParameter);
                 }
@@ -141,8 +141,27 @@ public class ModuleWeaver
     }
 
 
-    private string ToPropertyName(string fieldName)
+    private static string ToPropertyName(string fieldName)
     {
         return Char.ToUpperInvariant(fieldName[0]) + fieldName.Substring(1);
     }
+
+    private static IEnumerable<PropertyDefinition> GetAllProperties(TypeDefinition type)
+    {
+        // get recursively through the hierachy all the properties with a public getter
+        return type.Properties.Where(pro => pro.GetMethod.IsPublic)
+            .Concat(type.BaseType == null ?
+                Enumerable.Empty<PropertyDefinition>() :
+                GetAllProperties(type.BaseType.Resolve()));
+    }
+
+    private static MethodDefinition GetPropertyGetter(TypeDefinition type, string name)
+    {
+        // get the getter for the property anywhere in the hierachy with the given name
+        return GetAllProperties(type)
+            .Where(pro => String.Compare(pro.Name, name, StringComparison.InvariantCultureIgnoreCase) == 0)
+            .Select(pro => pro.GetMethod)
+            .First();
+    }
+
 }

--- a/With.Fody/ModuleWeaver.cs
+++ b/With.Fody/ModuleWeaver.cs
@@ -24,12 +24,18 @@ public class ModuleWeaver
         foreach (var type in ModuleDefinition.Types
             .Where(type => type.GetMethods().Any(m => m.IsPublic && m.Name.StartsWith("With"))))
         {
-            var ctor = GetValidConstructor(type);
-            if (ctor != null)
+            try
             {
-                AddWith(type, ctor);
-                RemoveGenericWith(type);
-                LogInfo($"Added method 'With' to type '{type.Name}'.");
+                var ctor = GetValidConstructor(type);
+                if (ctor != null)
+                {
+                    AddWith(type, ctor);
+                    RemoveGenericWith(type);
+                    LogInfo($"Added method 'With' to type '{type.Name}'.");
+                }
+            }
+            catch (AssemblyResolutionException ex) {
+                LogInfo($"Type '{type.Name}' references another assembly '{ex.AssemblyReference.FullName}'.");
             }
         }
     }


### PR DESCRIPTION
Cecil ignores inherited properties so, With.Fody does not support inheritance. I added a GetAllProperties() that goes up the hierarchy to get all the properties. 
Added exception handling to gracefully step over any assembly resolution issue. 
Added the test cases Inheritance, that inherits from a class in the same assembly, and ReferenceInheritance, that inherits from a class in the ReferenceAssembly assembly.

Supports cases like this one:
``` csharp
    public class BaseInheritance
    {
        public BaseInheritance(int value1, string value2)
        {
            this.Value1 = value1;
            this.Value2 = value2;
        }

        public int Value1 { get; }

        public string Value2 { get; }

        public BaseInheritance With<T>(T value) => this;
    }

    public class Inheritance : BaseInheritance
    {
        public Inheritance(int value1, string value2, long value3)
            : base(value1, value2)
        {
            this.Value3 = value3;
        }

        public long Value3 { get; }

        public new Inheritance With<T>(T value) => this;
    }
```
