### PR TITLE
Cache name and version of assembly in GeneratedCodeAttribute()

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-	<Version>0.9.0</Version>
+	<Version>0.9.1</Version>
     <LangVersion>7.3</LangVersion>
     <Features>strict</Features>
   </PropertyGroup>


### PR DESCRIPTION
The PR #16 introduced the addition of  `[GeneratedCode("With.Fody", "0.9.0")]` attribute to the generated methods. This doesn't change the behavior of the code but makes it easier to find in a decompiler what methods were generated by this addin and what version was used. It uses reflection to get the up to date information.

This PR caches these values into lazy static variables. Reflection is only used the first time the method is called, improving performance of the addin.

The PR #16 also introduced the addition of `[MethodImpl(MethodImplOptions.AggressiveInlining)]` attribute to the generated methods. This improves performance of the compiled code by saving one method call. 

These attribute were only being added when a new `With` method was generated. This PR adds the attributes also to methods where only the body is changed by this addin.

