### PR TITLE
Use 'HasBody' and 'is object'.

### DIFF
--- a/With.Fody/ModuleWeaver.cs
+++ b/With.Fody/ModuleWeaver.cs
@@ -161,7 +161,7 @@ public class ModuleWeaver : BaseModuleWeaver
                     item.Parameter.ParameterType.FullName == ctorParameter.ParameterType.FullName && 
                     String.Compare(item.Parameter.Name, ctorParameter.Name, StringComparison.InvariantCultureIgnoreCase) == 0);
 
-            if (withParameter != null)
+            if (withParameter is object)
             {
                 processor.Emit(OpCodes.Ldarg, withParameter.Index + 1);
             }
@@ -179,8 +179,8 @@ public class ModuleWeaver : BaseModuleWeaver
     private void ReplaceCalls(TypeDefinition withType, MethodDefinition newMethod, TypeReference argumentType)
     {
         foreach (var call in ModuleDefinition.GetTypes()
-            .SelectMany(type => type.Methods.Where(x => x.Body != null))
-            .SelectMany(method => method.Body.Instructions.Where(i => i.OpCode == OpCodes.Callvirt)))
+            .SelectMany(type => type.Methods.Where(method => method.HasBody))
+            .SelectMany(method => method.Body.Instructions.Where(instruction => instruction.OpCode == OpCodes.Callvirt)))
         {
             var originalMethodReference = (MethodReference)call.Operand;
             if (originalMethodReference.IsGenericInstance)


### PR DESCRIPTION
This PR contains two small code refactors:
- Use `is object` instead of `!= null` as sujested by Jared Parson in this tweet: https://twitter.com/jaredpar/status/1115019017297596416
- Use `method.HasBody` instead of `method.Body != null` or `method.Body is object`
