### PR TITLE
Fix assembly reference for GeneratedCodeAttribute

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-	<Version>0.9.1</Version>
+	<Version>0.9.2</Version>
     <LangVersion>7.3</LangVersion>
     <Features>strict</Features>
   </PropertyGroup>


### PR DESCRIPTION
While looking at the generated IL, I found that `GeneratedCodeAttribute` was not referencing `netstandard`. It should have `[netstandard]` before any reference to framework entities.

The fix is based on a tip by @SimonCropp at https://github.com/jbevain/cecil/issues/591